### PR TITLE
Updated iso_url and iso_checksum

### DIFF
--- a/ubuntu/20/ubuntu20.json
+++ b/ubuntu/20/ubuntu20.json
@@ -9,9 +9,9 @@
       "type": "vsphere-iso",
       "iso_urls": [
         "ubuntu-20.04.1-legacy-server-amd64.iso",
-        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-amd64.iso"
+        "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso"
       ],
-      "iso_checksum": "sha256:36f15879bd9dfd061cd588620a164a82972663fdd148cce1f70d57d314c21b73",
+      "iso_checksum": "sha256:f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
       "vcenter_server": "{{user `vcsa_host`}}",
       "username": "{{user `vcsa_username`}}",
       "password": "{{user `vcsa_password`}}",


### PR DESCRIPTION
Updated Ubuntu ISO_URL and ISO_checksum for 20.04.1 support.